### PR TITLE
Removed analysis.2018-04-15_00.00.00.nc

### DIFF
--- a/testinput_tier_1/480km_2stream/analysis.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km_2stream/analysis.2018-04-15_00.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6cd71401364152dee13eac3c87be24fbfaa5a7de89f575b4401e59676a8fa639
-size 3886904


### PR DESCRIPTION
## Description
According to the issue https://github.com/JCSDA-internal/mpas-jedi/issues/624 and PR https://github.com/JCSDA-internal/mpas-jedi/pull/626, ```analysis.2018-04-15_00.00.00.nc``` should be removed from the directory ```testinput_tier_1/480km_2stream/```

LIST OF MODIFIED FILES:
D       testinput_tier_1/480km_2stream/analysis.2018-04-15_00.00.00.nc

Closes #2 

## Dependencies
Waiting on the following PR:
 - Waiting on https://github.com/JCSDA-internal/mpas-jedi/pull/626 

## TESTS CONDUCTED:
Ctests pass on Cheyenne.