### PR TITLE
Merge Release/mpas 1.0 back to develop branch

### DIFF
--- a/testinput_tier_1/480km_2stream/analysis.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km_2stream/analysis.2018-04-15_00.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6cd71401364152dee13eac3c87be24fbfaa5a7de89f575b4401e59676a8fa639
-size 3886904


### PR DESCRIPTION
TYPE: maintenance

DESCRIPTION OF CHANGES: The PR merges the efforts for JEDI-MPAS 1.0.0 release back to develop branch.

LIST OF MODIFIED FILES:
D       testinput_tier_1/480km_2stream/analysis.2018-04-15_00.00.00.nc

TESTS CONDUCTED: CI tests pass.