### PR TITLE
 split obs for append ctest

### DIFF
--- a/testinput_tier_1/obs/mpasobsappend1/sondes_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/mpasobsappend1/sondes_obs_2018041500_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8be73fa50d0b9808ae0ca60517000143bff1f649104811790740d7513b29088
+size 277763

--- a/testinput_tier_1/obs/mpasobsappend2/sondes_obs_2018041500_m.nc4
+++ b/testinput_tier_1/obs/mpasobsappend2/sondes_obs_2018041500_m.nc4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d59a2dcfe5bbdd7f9a32acfa907839688920559672fecb418ee0935f0bd723d
+size 272568


### PR DESCRIPTION
## Description

Adds split radio sonde observations for use in an mpas-jedi ctest which exercises the append functionality in oops. 
This PR goes with https://github.com/JCSDA-internal/mpas-jedi/pull/1008/

## Issue(s) addressed

Resolves #1007

## Dependencies

List the other PRs that this PR is dependent on:
- [ ] ...

## Impact

Expected impact on downstream repositories:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x ] I have run the unit tests before creating the PR
