### PR TITLE
Update push-to-s3 - move to public requester-pays bucket.

### DIFF
--- a/.github/workflows/push-to-s3.yaml
+++ b/.github/workflows/push-to-s3.yaml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - develop
+  pull_request:
+    branches:
+      - develop
   schedule:
     # 1:30 AM on the 1st and 15th day of each month.
     - cron: 30 1 1,15 * *

--- a/.github/workflows/push-to-s3.yaml
+++ b/.github/workflows/push-to-s3.yaml
@@ -9,6 +9,7 @@ on:
   schedule:
     # 1:30 AM on the 1st and 15th day of each month.
     - cron: 30 1 1,15 * *
+  workflow_dispatch: {}
 
 jobs:
   upload:
@@ -33,7 +34,7 @@ jobs:
 
       - name: Create tarball and upload to s3
         env:
-          LFS_BUCKET_AND_PATH: jcsda-usaf-ci-build-cache/lfs
+          LFS_BUCKET_AND_PATH: jcsda-public-rpays/JCSDA-internal
         run: |
           export repository_name=$(basename $(pwd))
           echo "Prep repo ${repository_name} for upload"

--- a/.github/workflows/push-to-s3.yaml
+++ b/.github/workflows/push-to-s3.yaml
@@ -37,9 +37,13 @@ jobs:
 
       - name: Create tarball and upload to s3
         env:
-          LFS_BUCKET_AND_PATH: jcsda-public-rpays/JCSDA-internal
+          LFS_BUCKET: jcsda-public-rpays
         run: |
           export repository_name=$(basename $(pwd))
+          export org_name="${GITHUB_REPOSITORY_OWNER}"
+          export LFS_BUCKET_AND_PATH="${LFS_BUCKET}/${org_name}"
+          echo "Detected organization: ${org_name}"
+          echo "Using S3 path: ${LFS_BUCKET_AND_PATH}"
           echo "Prep repo ${repository_name} for upload"
           git fetch --all
           git checkout develop

--- a/.github/workflows/push-to-s3.yaml
+++ b/.github/workflows/push-to-s3.yaml
@@ -6,9 +6,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
-    branches:
-      - develop
   schedule:
     # 1:30 AM on the 1st and 15th day of each month.
     - cron: 30 1 1,15 * *
@@ -43,8 +40,8 @@ jobs:
           export org_name="${GITHUB_REPOSITORY_OWNER}"
           export LFS_BUCKET_AND_PATH="${LFS_BUCKET}/${org_name}"
           echo "Detected organization: ${org_name}"
-          echo "Using S3 path: ${LFS_BUCKET_AND_PATH}"
-          echo "Prep repo ${repository_name} for upload"
+          echo "Uploading repository to s3://${LFS_BUCKET_AND_PATH}/${repository_name}.tar.gz"
+          echo "Preparing ${repository_name} for upload"
           git fetch --all
           git checkout develop
           git config --local --remove-section 'http.https://github.com/'


### PR DESCRIPTION
This update changes the upload bucket for our s3 data with the rationale of (1) ending object expiration and (2) moving to _requester pays_.

__Object Expiration:__
The old bucket had object expiration which caused problems with GitHub's behavior of disabling actions on repositories with limited activity.

__Requester Pays:__
The new bucket is public to logged-in users (no anonymous access) and is configured with the _requester pays_ behavior so that egress charges are billed to the account originating the file egress than to the account that owns the bucket (our account). In practice we expect JCSDA to be responsible for the majority of egress traffic but if this changes we will not be responsible for high utilization billing.


## Checklist

- [x] I have performed a self-review of my own code
- __N/A__ I have made corresponding changes to the documentation
- __N/A__ I have run the unit tests before creating the PR
