### PR TITLE
Add files which support 2 stream I/O. Delete the files they replace.

### DIFF
--- a/testinput_tier_1/384km/bg/mpasout.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/384km/bg/mpasout.2018-04-15_00.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd4f5ce52fa2890f145369a47c8ee6b06ce563c6e17164d672ec5507e8dd20d9
+size 3332664

--- a/testinput_tier_1/384km/bg/x1.4002.invariant.nc
+++ b/testinput_tier_1/384km/bg/x1.4002.invariant.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ea1bde9308cce68e8eb0fea60642836e7d0f83e2503261ceb50325b875126e8
+size 8756868

--- a/testinput_tier_1/384km/init/x1.4002.init.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/384km/init/x1.4002.init.2018-04-15_00.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ec534db7f9cff36e55795090e055fbbf9469f9021b826ba3e943b39176bce00e
-size 19225784

--- a/testinput_tier_1/480km/bg/ensemble/mem01/EnsForCov.2018-04-14_21.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem01/EnsForCov.2018-04-14_21.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4ca2fff70d1f26c92f8a31a0a2b78147e2f2158f39371197849ea1b4348115b
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem01/EnsForCov.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem01/EnsForCov.2018-04-15_00.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff94f4bad2911bbb89e631a19e205a52b3ffbbb9ab828944e26598011b7d8f10
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem01/EnsForCov.2018-04-15_03.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem01/EnsForCov.2018-04-15_03.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74fb110a45abb87fd7b13d66c5507226a83f5501cd04891b1d9a6d9cc6f9755a
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem01/x1.2562.init.2018-04-14_21.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem01/x1.2562.init.2018-04-14_21.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b7f69e40dbf6a2224e7163b1f9b3ae5b81c96401eda68178f2e23ce539896450
-size 13521432

--- a/testinput_tier_1/480km/bg/ensemble/mem01/x1.2562.init.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem01/x1.2562.init.2018-04-15_00.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d61b9f778d47698fee76587445b2845c6b36767e927aba26943916e149607a4a
-size 13521432

--- a/testinput_tier_1/480km/bg/ensemble/mem01/x1.2562.init.2018-04-15_03.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem01/x1.2562.init.2018-04-15_03.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:678bcd172cf184c8ee3fc768b1444d99e91bacdf56caec7bfff1b786c5fb3cff
-size 13521432

--- a/testinput_tier_1/480km/bg/ensemble/mem02/EnsForCov.2018-04-14_21.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem02/EnsForCov.2018-04-14_21.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:071829fffbb9210d76ad3d393de5bfbc59016fdc82c226e828c3b1e40bd8c529
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem02/EnsForCov.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem02/EnsForCov.2018-04-15_00.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:595a98a158222714d6c01bccf9fc959678c185786b029e43eedd7926452b5e50
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem02/EnsForCov.2018-04-15_03.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem02/EnsForCov.2018-04-15_03.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29e11b25032d36550d4bfde5f5136620bc7edb9829f3ecab1b5957315baecd81
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem02/x1.2562.init.2018-04-14_21.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem02/x1.2562.init.2018-04-14_21.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a806c05ec78fb85811fc775947418008c9af088dcd70413819d550637e4c691c
-size 13521432

--- a/testinput_tier_1/480km/bg/ensemble/mem02/x1.2562.init.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem02/x1.2562.init.2018-04-15_00.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea87b93ea2158853e60f2a86b75c3647a08f0312ef7be729aaa75ff6f97b2c73
-size 13521432

--- a/testinput_tier_1/480km/bg/ensemble/mem02/x1.2562.init.2018-04-15_03.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem02/x1.2562.init.2018-04-15_03.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:750e3a323a43c5f30d697fa7090953f2931b4f09a1cd9446d57041c4039cfc00
-size 13521432

--- a/testinput_tier_1/480km/bg/ensemble/mem03/EnsForCov.2018-04-14_21.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem03/EnsForCov.2018-04-14_21.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f19b7fb0171a50f1c6190f2c635b72e24d1e747e4d352a3a375d203156bd0ed3
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem03/EnsForCov.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem03/EnsForCov.2018-04-15_00.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:326c48535cbf7c6f45e195ee66be2d05a8270064d584848149b8beb3c48b7205
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem03/EnsForCov.2018-04-15_03.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem03/EnsForCov.2018-04-15_03.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cab9c95b9a6aa8f0ba0f0de872f7dfdc74f7b3d1f5a052c7bb85770337ba8551
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem03/x1.2562.init.2018-04-14_21.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem03/x1.2562.init.2018-04-14_21.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4491c14b25bf8af5b8222a1e804af1242230f4d29b50abd32e2244b3d28cb4b4
-size 13521432

--- a/testinput_tier_1/480km/bg/ensemble/mem03/x1.2562.init.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem03/x1.2562.init.2018-04-15_00.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bb6e9608edf38a38b53e81f66466db12376014446f17a14106c7326919ddaf8e
-size 13521432

--- a/testinput_tier_1/480km/bg/ensemble/mem03/x1.2562.init.2018-04-15_03.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem03/x1.2562.init.2018-04-15_03.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f03d1c1ae45f56bc19827d96dc1e897accccb691eda5e54369293612ab6e5f31
-size 13521432

--- a/testinput_tier_1/480km/bg/ensemble/mem04/EnsForCov.2018-04-14_21.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem04/EnsForCov.2018-04-14_21.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:608f20c77cb0da155460b46449ecf012dcb0044e84159cae4a200a150c260571
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem04/EnsForCov.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem04/EnsForCov.2018-04-15_00.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b93d21cf1db40a347a7bafd34f872ba269668a6a3f2ee69f2f066e1e8e4379e5
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem04/EnsForCov.2018-04-15_03.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem04/EnsForCov.2018-04-15_03.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f6d66efc31c2fd2c319f6c454d8821bbb441ceb53fe08af7e220d44ff81eb40
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem04/x1.2562.init.2018-04-14_21.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem04/x1.2562.init.2018-04-14_21.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3d2b9448de368b0b2371454a410b89c8efac05caa6d91760ae921baae34c41e
-size 13521432

--- a/testinput_tier_1/480km/bg/ensemble/mem04/x1.2562.init.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem04/x1.2562.init.2018-04-15_00.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc5705e2f3f93bef2dc9267c56fa1750f952b6d529d20eadb6e297b9528c43f0
-size 13521432

--- a/testinput_tier_1/480km/bg/ensemble/mem04/x1.2562.init.2018-04-15_03.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem04/x1.2562.init.2018-04-15_03.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9e3906aa2e018a07817a8bd81393cdd380b187a9df2e8ad6c4fe035843ee00e
-size 13521432

--- a/testinput_tier_1/480km/bg/ensemble/mem05/EnsForCov.2018-04-14_21.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem05/EnsForCov.2018-04-14_21.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32d2ab689ec47d4fa05ff4498a5db560ad78fe5a9b6cf58d0a350dcb50100c1c
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem05/EnsForCov.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem05/EnsForCov.2018-04-15_00.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc26d58732be72daf39602de931428277cf57dcd2fa130a965e59fead602bfc8
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem05/EnsForCov.2018-04-15_03.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem05/EnsForCov.2018-04-15_03.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:daff05cf4fb3c0ec79736ed3e70549b02d5e18cee331e3602cdc36e94464973c
+size 879176

--- a/testinput_tier_1/480km/bg/ensemble/mem05/x1.2562.init.2018-04-14_21.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem05/x1.2562.init.2018-04-14_21.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d19cefde557bce5617283db02fc8d83c99feed40bbaa8e22089d1754e2bff5ba
-size 13521432

--- a/testinput_tier_1/480km/bg/ensemble/mem05/x1.2562.init.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem05/x1.2562.init.2018-04-15_00.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06ae22d9fc3e7cf4661a4857b506c7c5898f8bc89ce5572c8283b9712bf88375
-size 13521432

--- a/testinput_tier_1/480km/bg/ensemble/mem05/x1.2562.init.2018-04-15_03.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem05/x1.2562.init.2018-04-15_03.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9ce69166a1309654b1cb6c2f6844e57e6471e9c99e9675573e8c019f8e889fa
-size 13521432

--- a/testinput_tier_1/480km/bg/mpasout.2018-04-14_21.00.00.nc
+++ b/testinput_tier_1/480km/bg/mpasout.2018-04-14_21.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82ecb0cae202fe06e3309cb350a78e0ad1deff1e5038baeac2926768daa3c770
+size 2180664

--- a/testinput_tier_1/480km/bg/mpasout.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/mpasout.2018-04-15_00.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f81a81a378d3978abcea84c8d21d46e2fd511feed894ee23233d991a59d31649
+size 2180664

--- a/testinput_tier_1/480km/bg/mpasout.2018-04-15_03.00.00.nc
+++ b/testinput_tier_1/480km/bg/mpasout.2018-04-15_03.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53ce64fdc6c153cdd20492f57b1faaced7d6b9fce3943f6bcbba7655d687cd7b
+size 2180664

--- a/testinput_tier_1/480km/bg/restart.2018-04-14_21.00.00.nc
+++ b/testinput_tier_1/480km/bg/restart.2018-04-14_21.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4dc1101df1ca1dc760612af9f417099b92b78db703a9b7d94d5e67c6ee1c47c5
-size 39683768

--- a/testinput_tier_1/480km/bg/restart.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/restart.2018-04-15_00.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c7c4d2951caca8f8eae9288d89121c15ffa9ccfb4b2f98f99f7c3ceed3a7e3f6
-size 39683768

--- a/testinput_tier_1/480km/bg/restart.2018-04-15_03.00.00.nc
+++ b/testinput_tier_1/480km/bg/restart.2018-04-15_03.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c901aadae3873595b20af79226cc720e0a30e917f7d827c8dba63dea55f4c21
-size 39683768

--- a/testinput_tier_1/480km/bg/x1.2562.invariant.nc
+++ b/testinput_tier_1/480km/bg/x1.2562.invariant.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5396e543329aa14aae4528aa9ba649bf678c352d81327daca90b771172f902f8
+size 6758628

--- a/testinput_tier_1/480km_2stream/mpasout.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km_2stream/mpasout.2018-04-15_00.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6cd71401364152dee13eac3c87be24fbfaa5a7de89f575b4401e59676a8fa639
-size 3886904

--- a/testinput_tier_1/480km_2stream/static.nc
+++ b/testinput_tier_1/480km_2stream/static.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:912ff269cc019a867ed7322f7de9c5ab4e194b5ec003c8933a9a1ce0f8707cbc
-size 13590104

--- a/testinput_tier_1/480km_2stream/x1.2562.grid.nc
+++ b/testinput_tier_1/480km_2stream/x1.2562.grid.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d483ba28905b9f35a0eecd4612bd22a67e45274d6a64666ec122e31eb8248da
-size 3627528

--- a/testinput_tier_1/480km_2stream/x1.2562.init.2018-04-14_18.00.00.nc
+++ b/testinput_tier_1/480km_2stream/x1.2562.init.2018-04-14_18.00.00.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:912ff269cc019a867ed7322f7de9c5ab4e194b5ec003c8933a9a1ce0f8707cbc
-size 13590104


### PR DESCRIPTION
## Description
The new data sets were generated using a 2 stream input strategy with a single precision build of mpas-model.
## Issue(s) addressed

## Dependencies

List the other PRs that this PR is dependent on:
- [https://github.com/JCSDA-internal/mpas-jedi-data.git ] 

## Impact

Expected impact on downstream repositories: None

## Manual Testing Instructions (optional)
Build mpas-bundle using the feature/testdata_2stream branch of mpas-jedi. The run the mpas-jedi ctests.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the mpas-jedi ctests before creating the PR
