### PR TITLE
Add two regional dataset including one set of ensemble

### DIFF
--- a/testinput_tier_1/384km/bg/conus384km.graph.info
+++ b/testinput_tier_1/384km/bg/conus384km.graph.info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f950be932446736b5dc275e8d2fc648368c3c0bec3411857693fc45a54068fd
+size 13024

--- a/testinput_tier_1/384km/bg/conus384km.invariant.nc
+++ b/testinput_tier_1/384km/bg/conus384km.invariant.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4b7ea0130654071d2683b5dcbb9bfcb728f66d495406169690627db50ad9a1f
+size 1283732

--- a/testinput_tier_1/384km/bg/conus384km.mpasout.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/384km/bg/conus384km.mpasout.2018-04-15_00.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a1d4e0512b9af4d110734fb439e13dad9398e6fa8c90ecb9b8ef4c6b850d94d
+size 481456

--- a/testinput_tier_1/480km/bg/conus480km.graph.info
+++ b/testinput_tier_1/480km/bg/conus480km.graph.info
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1708f529bea59991ec384eb3e8112d219550da3d3844f9709c9950ed20a6423f
+size 10739

--- a/testinput_tier_1/480km/bg/conus480km.invariant.nc
+++ b/testinput_tier_1/480km/bg/conus480km.invariant.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0fcae244431d7e4daf9ccea78189dfd7e5fd55b226cccb3d84ac807b0e4e03b
+size 1289268

--- a/testinput_tier_1/480km/bg/conus480km.mpasout.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/conus480km.mpasout.2018-04-15_00.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54426d4386c095e3a137e5916a0d2285ad735892dc405a27fa706fc78a9bf2c2
+size 404536

--- a/testinput_tier_1/480km/bg/ensemble/mem01/conus480km.EnsForCov.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem01/conus480km.EnsForCov.2018-04-15_00.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c12d125c33e4800c571338b1de79f66afaaaa6cd2f636ed22cee8fe97e7c3fab
+size 153804

--- a/testinput_tier_1/480km/bg/ensemble/mem02/conus480km.EnsForCov.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem02/conus480km.EnsForCov.2018-04-15_00.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:464dc356f943b131a1306e974e08611ec15ad3b6fbc1efd654adaa30a60c4ae3
+size 153804

--- a/testinput_tier_1/480km/bg/ensemble/mem03/conus480km.EnsForCov.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem03/conus480km.EnsForCov.2018-04-15_00.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebcd7a9de837b639a4413913cfa65ba67a8f9609a8130a6c16566c4bc6c761d8
+size 153804

--- a/testinput_tier_1/480km/bg/ensemble/mem04/conus480km.EnsForCov.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem04/conus480km.EnsForCov.2018-04-15_00.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d1a8229e35130cd49ab156283412d2b8e60c91d5258082bb39f7ee2938bbeb1
+size 153804

--- a/testinput_tier_1/480km/bg/ensemble/mem05/conus480km.EnsForCov.2018-04-15_00.00.00.nc
+++ b/testinput_tier_1/480km/bg/ensemble/mem05/conus480km.EnsForCov.2018-04-15_00.00.00.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f64e35f9620abc2ae0a659902ee9d7127379520b888a94b39f1c67af58dfebca
+size 153804


### PR DESCRIPTION
## Description

This PR is a companion to JCSDA-internal/mpas-jedi#1189. This PR adds the dataset with the regional meshes, which are cut from the corresponding global mesh dataset, centered over CONUS.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
